### PR TITLE
🔒 [security fix] Sanitize markdown and external links in NewsSection

### DIFF
--- a/src/components/NewsSection.tsx
+++ b/src/components/NewsSection.tsx
@@ -37,7 +37,20 @@ const DETAILS_TRUNCATE_THRESHOLD = 100
 /** Safely render markdown to sanitized HTML */
 function renderMarkdown(text: string): string {
   const raw = marked.parse(text, { async: false }) as string
-  return DOMPurify.sanitize(raw)
+  return DOMPurify.sanitize(raw, {
+    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'p', 'br', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'code', 'pre', 'span', 'img'],
+    ALLOWED_ATTR: ['href', 'target', 'rel', 'title', 'class', 'src', 'alt'],
+  })
+}
+
+/** Sanitize an external URL to prevent javascript: and other dangerous protocols */
+function sanitizeUrl(url?: string): string | undefined {
+  if (!url) return undefined
+  // Strip dangerous protocols like javascript:
+  if (/^(javascript|data|vbscript):/i.test(url.trim())) {
+    return '#'
+  }
+  return url
 }
 
 /** Format a news date for display */
@@ -224,7 +237,7 @@ export default function NewsSection({ news = [], editMode, onUpdate, sectionLabe
                     )}
                     {item.link && (
                       <a
-                        href={item.link}
+                        href={sanitizeUrl(item.link)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1 text-xs text-primary/70 hover:text-primary mt-2 font-mono tracking-wider transition-colors"
@@ -442,7 +455,7 @@ function NewsDetailOverlay({ item, onClose, sectionLabels }: {
 
           {item.link && (
             <a
-              href={item.link}
+              href={sanitizeUrl(item.link)}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-4 py-2 border border-primary/40 bg-primary/10 hover:bg-primary/20 text-primary font-mono text-xs tracking-wider transition-all hover:shadow-[0_0_15px_var(--primary-glow)]"


### PR DESCRIPTION
Fixed XSS vulnerability in `src/components/NewsSection.tsx` by strengthening markdown sanitization and implementing URL protocol validation.

### 🎯 What
- Fixed an XSS vulnerability where untrusted HTML from markdown could be rendered via `dangerouslySetInnerHTML`.
- Fixed potential protocol-based XSS in external links.

### ⚠️ Risk
- Malicious actors could inject scripts into news item details or links, leading to session hijacking, data theft, or defacement when other users (especially admins) view the news section.

### 🛡️ Solution
- Updated `renderMarkdown` to use an explicit `DOMPurify` allowlist for tags (`b`, `i`, `em`, `strong`, `a`, `p`, `br`, `ul`, `ol`, `li`, `h1`-`h6`, `blockquote`, `code`, `pre`, `span`, `img`) and attributes (`href`, `target`, `rel`, `title`, `class`, `src`, `alt`).
- Added a `sanitizeUrl` helper function that strips `javascript:`, `data:`, and `vbscript:` protocols from URLs.
- Wrapped all `item.link` usages in `href` attributes with `sanitizeUrl`.

---
*PR created automatically by Jules for task [6444651557522576712](https://jules.google.com/task/6444651557522576712) started by @Neuroklast*