### PR TITLE
fix: Theme loading screen stuck resolution

### DIFF
--- a/src/themes/glitch-noir/LoadingScreen.tsx
+++ b/src/themes/glitch-noir/LoadingScreen.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
+import type { LoadingScreenSlotProps } from '@/lib/types'
 
 const NK_BOOT_TEXT = 'NK://BOOT'
 const LOADING_SEQUENCE_LABEL = '[LOADING_SEQUENCE]'
@@ -16,7 +17,7 @@ const BOOT_SEQUENCE = [
   '/// NEUROKLAST_ONLINE ///'
 ]
 
-export default function LoadingScreen() {
+export default function LoadingScreen({ onComplete }: LoadingScreenSlotProps) {
   const [progress, setProgress] = useState(0)
   const [messages, setMessages] = useState<string[]>([])
   const [noiseLevel, setNoiseLevel] = useState(0)
@@ -34,6 +35,17 @@ export default function LoadingScreen() {
 
     return () => clearInterval(interval)
   }, [])
+
+  useEffect(() => {
+    if (progress >= 100) {
+      const t = setTimeout(() => {
+        if (onComplete) {
+          onComplete()
+        }
+      }, 200)
+      return () => clearTimeout(t)
+    }
+  }, [progress, onComplete])
 
   useEffect(() => {
     const noiseInterval = setInterval(() => {

--- a/src/themes/umbrella-corp/LoadingScreen.tsx
+++ b/src/themes/umbrella-corp/LoadingScreen.tsx
@@ -22,7 +22,6 @@ export default function LoadingScreen({ onComplete }: LoadingScreenSlotProps) {
         if (prev >= 100) {
           clearInterval(progressTimer)
           clearInterval(lineTimer)
-          setTimeout(() => onComplete(), 200)
           return 100
         }
         return prev + 2
@@ -33,7 +32,18 @@ export default function LoadingScreen({ onComplete }: LoadingScreenSlotProps) {
       clearInterval(lineTimer)
       clearInterval(progressTimer)
     }
-  }, [onComplete])
+  }, [])
+
+  useEffect(() => {
+    if (progress >= 100) {
+      const t = setTimeout(() => {
+        if (onComplete) {
+          onComplete()
+        }
+      }, 200)
+      return () => clearTimeout(t)
+    }
+  }, [progress, onComplete])
 
   return (
     <motion.div

--- a/src/themes/zardonic-industrial/LoadingScreen.tsx
+++ b/src/themes/zardonic-industrial/LoadingScreen.tsx
@@ -30,7 +30,6 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
         if (prev >= 100) {
           clearInterval(progressInterval)
           clearInterval(textInterval)
-          setTimeout(() => onComplete(), 200)
           return 100
         }
         return prev + 2
@@ -41,7 +40,18 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
       clearInterval(textInterval)
       clearInterval(progressInterval)
     }
-  }, [onComplete])
+  }, [])
+
+  useEffect(() => {
+    if (progress >= 100) {
+      const t = setTimeout(() => {
+        if (onComplete) {
+          onComplete()
+        }
+      }, 200)
+      return () => clearTimeout(t)
+    }
+  }, [progress, onComplete])
 
   return (
     <motion.div


### PR DESCRIPTION
Fixes a bug where applying a new theme caused the UI to become permanently stuck on the loading screen because `onComplete` was never being called or was being called from an impure state updater function.

---
*PR created automatically by Jules for task [11044285352024717310](https://jules.google.com/task/11044285352024717310) started by @Neuroklast*