### PR TITLE
Fix theme color desync, contrast readability, and hero tint

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -179,11 +179,14 @@ export default function Hero({ name, genres, logoUrl, titleImageUrl, heroStyle }
             </Suspense>
           ) : heroStyle === 'minimal' ? (
             /* Minimal — plain logo without effects */
-            <img
-              src={logoUrl ?? logoPng}
-              alt={t('hero.logoAlt').replace('{0}', name)}
-              className="w-[20rem] h-auto sm:w-[24rem] md:w-[28rem] lg:w-[32rem] xl:w-[36rem]"
-            />
+            <div className="relative isolate block w-fit">
+              <img
+                src={logoUrl ?? logoPng}
+                alt={t('hero.logoAlt').replace('{0}', name)}
+                className="w-[20rem] h-auto sm:w-[24rem] md:w-[28rem] lg:w-[32rem] xl:w-[36rem] relative z-10"
+              />
+              <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
+            </div>
           ) : (
             /* Default / chromatic-hover — original glitch + scanline overlay */
             <div 
@@ -201,11 +204,14 @@ export default function Hero({ name, genres, logoUrl, titleImageUrl, heroStyle }
                   chromatische Aberration beim Hover (CSS-Klasse hero-logo-chromatic-hover).
                 */}
                 <div className="hero-logo-chromatic-hover">
-                  <img 
-                    src={logoUrl ?? logoPng} 
-                    alt={t('hero.logoAlt').replace('{0}', name)} 
-                    className={`w-[20rem] h-auto sm:w-[24rem] md:w-[28rem] lg:w-[32rem] xl:w-[36rem]`}
-                  />
+                  <div className="relative isolate block w-fit mx-auto">
+                    <img
+                      src={logoUrl ?? logoPng}
+                      alt={t('hero.logoAlt').replace('{0}', name)}
+                      className={`w-[20rem] h-auto sm:w-[24rem] md:w-[28rem] lg:w-[32rem] xl:w-[36rem] relative z-10`}
+                    />
+                    <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
+                  </div>
                 </div>
                 <div className="absolute inset-0 pointer-events-none z-20" style={{ mixBlendMode: 'multiply' }}>
                   <div 
@@ -253,11 +259,14 @@ export default function Hero({ name, genres, logoUrl, titleImageUrl, heroStyle }
                 Silhouette des Bildes. Der Wrapper darf außerdem KEIN overflow:hidden haben.
               */}
               <div style={{ filter: `drop-shadow(2px 0 0 color-mix(in oklch, var(--primary) 80%, transparent)) drop-shadow(-2px 0 0 color-mix(in oklch, var(--primary) 80%, transparent)) drop-shadow(0 0 10px color-mix(in oklch, var(--primary) 40%, transparent))` }}>
-                <img 
-                  src={titleImageUrl ?? titlePng} 
-                  alt={t('hero.titleAlt').replace('{0}', name)} 
-                  className={`w-full h-auto`}
-                />
+                <div className="relative isolate block w-full">
+                  <img
+                    src={titleImageUrl ?? titlePng}
+                    alt={t('hero.titleAlt').replace('{0}', name)}
+                    className={`w-full h-auto relative z-10`}
+                  />
+                  <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
+                </div>
               </div>
               <div className="absolute inset-0 pointer-events-none z-20" style={{ mixBlendMode: 'multiply' }}>
                 <div 

--- a/src/components/HeroZardonic.tsx
+++ b/src/components/HeroZardonic.tsx
@@ -197,11 +197,14 @@ export default function HeroZardonic({
                 Silhouette des Bildes. Der Wrapper darf außerdem KEIN overflow:hidden haben.
               */}
               <div style={!glitchLogo ? { filter: 'drop-shadow(0 0 30px oklch(0.45 0.22 25 / 0.8))' } : undefined}>
-                <img
-                  src={logoUrl ?? logoPng}
-                  alt={`${name} Logo`}
-                  className={`w-[20rem] h-auto sm:w-[24rem] md:w-[28rem] lg:w-[32rem] xl:w-[36rem] ${glitchLogo ? 'red-glitch-element' : ''}`}
-                />
+                <div className="relative isolate block w-fit mx-auto">
+                  <img
+                    src={logoUrl ?? logoPng}
+                    alt={`${name} Logo`}
+                    className={`w-[20rem] h-auto sm:w-[24rem] md:w-[28rem] lg:w-[32rem] xl:w-[36rem] relative z-10 ${glitchLogo ? 'red-glitch-element' : ''}`}
+                  />
+                  <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
+                </div>
               </div>
               {/* CRT scanline overlay on logo */}
               <div className="absolute inset-0 pointer-events-none z-20" style={{ mixBlendMode: 'multiply' }}>
@@ -251,11 +254,14 @@ export default function HeroZardonic({
                 Silhouette des Bildes. Der Wrapper darf außerdem KEIN overflow:hidden haben.
               */}
               <div style={{ filter: `drop-shadow(2px 0 0 oklch(0.50 0.22 25 / 0.8)) drop-shadow(-2px 0 0 oklch(0.50 0.22 25 / 0.8)) drop-shadow(0 0 10px oklch(0.50 0.22 25 / 0.4))` }}>
-                <img
-                  src={titleImageUrl ?? titlePng}
-                  alt={name}
-                  className={`w-full h-auto ${glitchTitle ? 'red-glitch-element' : ''}`}
-                />
+                <div className="relative isolate block w-full">
+                  <img
+                    src={titleImageUrl ?? titlePng}
+                    alt={name}
+                    className={`w-full h-auto relative z-10 ${glitchTitle ? 'red-glitch-element' : ''}`}
+                  />
+                  <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
+                </div>
               </div>
               {/* CRT scanline + dot-matrix overlays */}
               <div className="absolute inset-0 pointer-events-none z-20" style={{ mixBlendMode: 'multiply' }}>

--- a/src/components/PartnersAndFriendsSection.tsx
+++ b/src/components/PartnersAndFriendsSection.tsx
@@ -137,20 +137,20 @@ function FriendCard({ friend, editMode, onUpdate, onDelete, onSelect }: {
 
   return (
     <Card
-      className="bg-card/50 border-border hover:border-primary/50 transition-all duration-300 overflow-hidden group hud-element hud-corner cursor-pointer"
+      className="bg-card/50 border-border hover:border-primary/50 transition-all duration-300 overflow-hidden group hud-element hud-corner cursor-pointer h-full"
       onClick={() => !editMode && onSelect()}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
       <span className="corner-bl"></span>
       <span className="corner-br"></span>
-      <div className="flex flex-col items-center gap-3 p-5">
+      <div className="flex flex-col items-center gap-3 p-5 h-full">
         {(friend.iconPhoto || friend.photo) ? (
           <div className={`relative w-24 h-24 aspect-square flex-shrink-0 overflow-hidden border border-primary/30 shadow-[0_0_15px_var(--primary-glow),0_0_30px_var(--primary-glow-dim)] bg-black`}>
             <ProgressiveImage
               src={friend.iconPhoto || friend.photo || ''}
               alt={friend.name}
-              className="w-full h-full object-contain"
+              className="w-full h-full object-cover"
             />
             <div className="dot-matrix-photo" />
           </div>
@@ -159,7 +159,7 @@ function FriendCard({ friend, editMode, onUpdate, onDelete, onSelect }: {
             <User size={32} className="text-muted-foreground/40" />
           </div>
         )}
-        <div className="text-center min-w-0 w-full">
+        <div className="text-center min-w-0 w-full flex-grow flex flex-col justify-start">
           <div className="flex items-center justify-center gap-2">
             <p className="text-sm font-bold line-clamp-1">{friend.name}</p>
             {editMode && (
@@ -298,10 +298,11 @@ export default function PartnersAndFriendsSection({ friends = [], editMode, onUp
           transition={{ duration: 0.6, delay: 0.2 }}
         />
 
-        <div className="partner-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="partner-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 items-stretch">
           {displayFriends.map((friend, index) => (
             <motion.div
               key={friend.id}
+              className="h-full"
               initial={{ opacity: 0, y: 20 }}
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
               transition={{ duration: 0.5, delay: index * 0.08 }}

--- a/src/components/ThemeCustomizerEffectsPanel.tsx
+++ b/src/components/ThemeCustomizerEffectsPanel.tsx
@@ -67,6 +67,20 @@ export default function ThemeCustomizerEffectsPanel({ themeSettings, activeTheme
           </button>
         </div>
 
+        <div className="flex items-center justify-between border-b border-primary/10 pb-2">
+          <div>
+            <span className="font-mono text-xs text-foreground/90 block">Hero Image Tint</span>
+            <span className="font-mono text-[9px] text-muted-foreground/60">Colorizes the hero image with the primary theme color</span>
+          </div>
+          <button
+            onClick={() => onUpdate({ ...themeSettings, heroImageTint: !themeSettings.heroImageTint })}
+            className={`flex items-center gap-2 px-3 py-1 rounded text-xs font-mono transition-colors ${themeSettings.heroImageTint ? 'text-primary bg-primary/10' : 'text-muted-foreground/40 bg-muted/20'}`}
+          >
+            {themeSettings.heroImageTint ? <Eye size={14} /> : <EyeSlash size={14} />}
+            {themeSettings.heroImageTint ? t('theme.on') : t('theme.off')}
+          </button>
+        </div>
+
         {GLOBAL_EFFECTS.map(effect => {
           const isEnabled = getAnimationEnabled(themeSettings, effect.id)
           const intensity = getAnimationIntensity(themeSettings, effect.id)

--- a/src/hooks/use-theme-customizer.ts
+++ b/src/hooks/use-theme-customizer.ts
@@ -104,13 +104,14 @@ export function useThemeCustomizer({
     const defaults = applyThemeDefaults(themeId)
     setPreviewConfig(prev => ({
       theme: themeId,
-      themeSettings: {
+      themeSettings: resolveColorsFromPreset({
         // Preserve only user-created custom presets across theme switches.
         customColorPresets: prev.themeSettings.customColorPresets,
         // New theme defaults override all previous color/font/effect settings.
         ...defaults,
         ...structuralPatch,
-      },
+        activePreset: themeId,
+      }),
     }))
     setHasEdits(true)
   }, [])

--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -29,6 +29,38 @@ export function oklchToHex(oklch: string): string {
  *
  * Falls back to `oklch(0.50 0.22 25)` when the color cannot be resolved.
  */
+/**
+ * Ensure a given foreground color is readable against a given background color.
+ * Works by parsing the lightness `L` value of `oklch(L C H)` strings.
+ * If the color cannot be parsed as OKLCH, returns the original color.
+ */
+export function ensureContrast(fgOklch: string, bgOklch: string): string {
+  const fgMatch = fgOklch.match(/oklch\(\s*([\d.]+)/)
+  const bgMatch = bgOklch.match(/oklch\(\s*([\d.]+)/)
+
+  if (fgMatch && bgMatch) {
+    const fgL = parseFloat(fgMatch[1])
+    const bgL = parseFloat(bgMatch[1])
+
+    // Background is light (L > 0.6)
+    if (bgL > 0.6) {
+      // Foreground is also light (L > 0.5) -> unreadable, make foreground dark
+      if (fgL > 0.5) {
+        return 'oklch(0.15 0 0)' // Dark
+      }
+    }
+    // Background is dark (L <= 0.6)
+    else {
+      // Foreground is also dark (L < 0.5) -> unreadable, make foreground light
+      if (fgL < 0.5) {
+        return 'oklch(0.95 0 0)' // Light
+      }
+    }
+  }
+
+  return fgOklch
+}
+
 export function hexToOklch(hex: string): string {
   const rgb = cssColorToRgb(hex)
   if (rgb) {

--- a/src/lib/theme-application.ts
+++ b/src/lib/theme-application.ts
@@ -6,6 +6,7 @@
 
 import type { ThemeSettings } from '@/lib/types'
 import { getTheme } from '@/lib/theme-registry'
+import { ensureContrast } from './color-utils'
 
 export const FONT_OPTIONS = [
   { label: 'JetBrains Mono', value: "'JetBrains Mono', monospace", google: false },
@@ -83,10 +84,17 @@ export function applyOverlayEffectsToDOM(theme: ThemeSettings | undefined) {
 function applyCSSVars(root: HTMLElement, theme: ThemeSettings) {
   if (theme.primary) root.style.setProperty('--primary', theme.primary)
   if (theme.accent) root.style.setProperty('--accent', theme.accent)
-  if (theme.background) root.style.setProperty('--background', theme.background)
-  if (theme.card) root.style.setProperty('--card', theme.card)
-  if (theme.foreground) root.style.setProperty('--foreground', theme.foreground)
-  if (theme.mutedForeground) root.style.setProperty('--muted-foreground', theme.mutedForeground)
+
+  const background = theme.background
+  const card = theme.card
+  const foreground = theme.foreground && background ? ensureContrast(theme.foreground, background) : theme.foreground
+  const mutedForeground = theme.mutedForeground && background ? ensureContrast(theme.mutedForeground, background) : theme.mutedForeground
+  const primaryForeground = theme.primaryForeground && theme.primary ? ensureContrast(theme.primaryForeground, theme.primary) : theme.primaryForeground
+
+  if (background) root.style.setProperty('--background', background)
+  if (card) root.style.setProperty('--card', card)
+  if (foreground) root.style.setProperty('--foreground', foreground)
+  if (mutedForeground) root.style.setProperty('--muted-foreground', mutedForeground)
   if (theme.border) root.style.setProperty('--border', theme.border)
   if (theme.secondary) root.style.setProperty('--secondary', theme.secondary)
   if (theme.fontBody) root.style.setProperty('--font-sans', theme.fontBody)
@@ -95,6 +103,9 @@ function applyCSSVars(root: HTMLElement, theme: ThemeSettings) {
   if (theme.fontHeading) {
     root.style.setProperty('--font-heading', theme.fontHeading)
   }
+
+  // Hero Image Tint
+  root.style.setProperty('--hero-image-tint', theme.heroImageTint ? '1' : '0')
 
   // Border radius
   // We set both --radius (used by index.css @theme) and --radius-factor
@@ -132,7 +143,9 @@ function applyCSSVars(root: HTMLElement, theme: ThemeSettings) {
   }
 
   // Extended color overrides — applied after the derived values so they take precedence
-  if (theme.primaryForeground) root.style.setProperty('--primary-foreground', theme.primaryForeground)
+  if (primaryForeground) root.style.setProperty('--primary-foreground', primaryForeground)
+  else if (theme.primaryForeground) root.style.setProperty('--primary-foreground', theme.primaryForeground)
+
   if (theme.cardForeground) root.style.setProperty('--card-foreground', theme.cardForeground)
   if (theme.popoverColor) root.style.setProperty('--popover', theme.popoverColor)
   if (theme.popoverForeground) root.style.setProperty('--popover-foreground', theme.popoverForeground)
@@ -260,15 +273,20 @@ export function applyThemeDefaults(themeId: string): Partial<ThemeSettings> {
   const theme = getTheme(themeId)
   if (!theme) return {}
   const result: Partial<ThemeSettings> = { activePreset: themeId }
-  if (theme.defaultColors) {
-    result.primary = theme.defaultColors.primary
-    result.accent = theme.defaultColors.accent
-    result.background = theme.defaultColors.background
-    result.card = theme.defaultColors.card
-    result.foreground = theme.defaultColors.foreground
-    result.mutedForeground = theme.defaultColors.mutedForeground
-    result.border = theme.defaultColors.border
-    result.secondary = theme.defaultColors.secondary
+
+  const defaultColors = theme.defaultColors
+    ?? theme.colorPresets?.find(p => p.id === theme.defaultPresetId)?.colors
+    ?? theme.colorPresets?.[0]?.colors
+
+  if (defaultColors) {
+    result.primary = defaultColors.primary
+    result.accent = defaultColors.accent
+    result.background = defaultColors.background
+    result.card = defaultColors.card
+    result.foreground = defaultColors.foreground
+    result.mutedForeground = defaultColors.mutedForeground
+    result.border = defaultColors.border
+    result.secondary = defaultColors.secondary
   }
   if (theme.defaultFonts) {
     result.fontHeading = theme.defaultFonts.heading

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -227,6 +227,8 @@ export interface ThemeSettings {
   heroButtons?: HeroButton[]
   /** User-created custom color presets (persisted in site config) */
   customColorPresets?: ColorPreset[]
+  /** Optional filter to tint the hero image with the primary color */
+  heroImageTint?: boolean
 }
 
 /** Individual overlay effect configuration */

--- a/src/themes/neuroklast-classic/Hero.tsx
+++ b/src/themes/neuroklast-classic/Hero.tsx
@@ -156,11 +156,14 @@ export default function NeuroklastClassicHero({
               Silhouette des Bildes. Der Wrapper darf außerdem KEIN overflow:hidden haben.
             */}
             <div style={{ filter: 'drop-shadow(0 0 20px var(--primary))' }}>
-              <img
-                src={logoUrl}
-                alt={`${name} Logo`}
-                className="w-[18rem] h-auto sm:w-[22rem] md:w-[26rem] lg:w-[30rem]"
-              />
+              <div className="relative isolate block w-fit mx-auto">
+                <img
+                  src={logoUrl}
+                  alt={`${name} Logo`}
+                  className="w-[18rem] h-auto sm:w-[22rem] md:w-[26rem] lg:w-[30rem] relative z-10"
+                />
+                <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
+              </div>
             </div>
           </motion.div>
         )}
@@ -183,11 +186,14 @@ export default function NeuroklastClassicHero({
                   'drop-shadow(0 0 30px var(--primary)) drop-shadow(2px 0 0 color-mix(in oklch, var(--primary) 70%, transparent)) drop-shadow(-2px 0 0 color-mix(in oklch, var(--primary) 70%, transparent))',
               }}
             >
-              <img
-                src={titleImageUrl}
-                alt={name}
-                className="w-full max-w-xs sm:max-w-md md:max-w-2xl lg:max-w-3xl h-auto"
-              />
+              <div className="relative isolate block w-full">
+                <img
+                  src={titleImageUrl}
+                  alt={name}
+                  className="w-full max-w-xs sm:max-w-md md:max-w-2xl lg:max-w-3xl h-auto relative z-10"
+                />
+                <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
+              </div>
             </div>
           ) : (
             <h1

--- a/src/themes/umbrella-corp/Hero.tsx
+++ b/src/themes/umbrella-corp/Hero.tsx
@@ -38,7 +38,7 @@ export default function Hero({ name, logoUrl, heroButtons, onContactModalOpen }:
       >
         {logoUrl ? (
           <motion.div
-            className="mb-8 relative mx-auto w-fit"
+            className="mb-8 relative mx-auto w-fit isolate"
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.6 }}
@@ -46,8 +46,9 @@ export default function Hero({ name, logoUrl, heroButtons, onContactModalOpen }:
             <img
               src={logoUrl}
               alt={name || 'Artist'}
-              className="h-40 md:h-56 lg:h-72 w-auto object-contain"
+              className="h-40 md:h-56 lg:h-72 w-auto object-contain relative z-10"
             />
+            <div className="absolute inset-0 z-20 pointer-events-none transition-opacity duration-300 mix-blend-color" style={{ backgroundColor: 'var(--primary)', opacity: 'var(--hero-image-tint, 0)' }} />
           </motion.div>
         ) : (
           <motion.h1


### PR DESCRIPTION
This PR addresses issues surrounding theme-switching color desyncs, contrast enforcement, optional hero tinting, and tile layout fixes:

1. **Theme Switch Colors**: Updates the `handleThemeSelect` handler to execute `resolveColorsFromPreset` mapping, ensuring custom color pickers and UI fully reflect the explicit new theme layout.
2. **Readability (Contrast)**: Enforces automatic dynamic contrast calculations by comparing OKLCH lightness levels during CSS root assignments in `theme-application.ts`. Text elements forcefully invert if they clash with their surface backgrounds.
3. **Hero Image Tint**: Adds a "Hero Image Tint" option in the Effects Panel. When enabled, a `mix-blend-color` overlay matching `--primary` is placed over `Hero` and `HeroZardonic` logos and title images to blend nicely with the active scheme.
4. **Partner/Friend Tiles**: Ensures consistent aspect ratios and height-matching on Friend cards. Updates `object-contain` to `object-cover` with `aspect-square`, forces `items-stretch` and `h-full` to the grid configuration in `PartnersAndFriendsSection.tsx`.

---
*PR created automatically by Jules for task [15133733999868597862](https://jules.google.com/task/15133733999868597862) started by @Neuroklast*