### PR TITLE
Fix friend/partner preview images cropping

### DIFF
--- a/src/components/PartnersAndFriendsSection.tsx
+++ b/src/components/PartnersAndFriendsSection.tsx
@@ -150,7 +150,7 @@ function FriendCard({ friend, editMode, onUpdate, onDelete, onSelect }: {
             <ProgressiveImage
               src={friend.iconPhoto || friend.photo || ''}
               alt={friend.name}
-              className="w-full h-full object-cover"
+              className="w-full h-full object-contain"
             />
             <div className="dot-matrix-photo" />
           </div>


### PR DESCRIPTION
The user reported that the preview photos in the friends section were cropped vertically or horizontally instead of fitting into their square containers.

To resolve this, I located the `FriendCard` rendering inside `src/components/PartnersAndFriendsSection.tsx` which wraps a `ProgressiveImage`. The styling classes originally forced `object-cover`, causing images to fill the box but clipping any parts that exceeded the container's aspect ratio.

I changed the image styling class from `object-cover` to `object-contain`. This maintains the square aspect ratio of the container but properly scales the inner images so they are fully visible without being cropped.

Tests were successfully run, and visual verification was confirmed via Playwright screenshot to ensure proper rendering.

---
*PR created automatically by Jules for task [14138249364336110657](https://jules.google.com/task/14138249364336110657) started by @Neuroklast*